### PR TITLE
Feature/rolling file appender base builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ license = "MIT/Apache-2.0"
 
 [dev-dependencies]
 tempfile = "3.0.5"
+tracing-appender = "0.2.3"
 
 [dependencies]
 chrono = "0.4"
+tracing-appender = { version = "0.2.3", optional = true }
+
+[features]
+non-blocking = ["dep:tracing-appender"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-rolling-file"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Cavivie <cavivie@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,45 @@ let file_appender = RollingFileAppenderBase::new(
     9
 ).unwrap();
 ```
+### Builder
+
+To simplify the creation of a `RollingFileAppenderBase`, an instance can be built as per the example below.
+
+```rust
+use tracing_rolling_file::*;
+
+let builder = RollingFileAppenderBase::builder();
+let appender = builder
+    .filename(String::from("/var/log/myprogram"))
+    .max_filecount(10)
+    .condition_max_file_size(100)
+    .build()
+    .unwrap();
+```
+
+### Non-blocking support
+
+To combine the `tracing_appender::non_blocking::NonBlocking` functionality, the feature needs to be enabled in Cargo.toml, i.e.
+
+```toml
+[dependencies]
+tracing-rolling-file = { version = "0.1.3", features = ["non-blocking"] }
+```
+
+Once enabled, you can use the method `get_non_blocking_appender` to generate
+a non-blocking version of the RollingFileAppenderBase.
+
+```rust
+use tracing_rolling_file::*;
+
+let file_appender = RollingFileAppenderBase::new(
+    "/var/log/myprogram",
+    RollingConditionBase::new().daily(),
+    9
+)?;
+let (non_blocking, _guard) = file_appender.get_non_blocking_appender();
+```
+
 
 ## Development
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -85,15 +85,13 @@ impl RollingCondition for RollingConditionBase {
     }
 }
 
-
-pub struct RollingFileAppenderBaseBuilder
-{
+pub struct RollingFileAppenderBaseBuilder {
     condition: RollingConditionBase,
     filename: String,
     max_filecount: usize,
     current_filesize: u64,
     writer_opt: Option<BufWriter<File>>,
-}    
+}
 
 impl Default for RollingFileAppenderBaseBuilder {
     fn default() -> Self {
@@ -151,21 +149,17 @@ impl RollingFileAppenderBaseBuilder {
     /// Returns an error if the filename is empty.
     pub fn build(self) -> Result<RollingFileAppenderBase, &'static str> {
         if self.filename.is_empty() {
-            return Err("A filename is required to be set and can not be blank")
+            return Err("A filename is required to be set and can not be blank");
         }
-        Ok(
-            RollingFileAppenderBase {
-                condition: self.condition,
-                filename: self.filename,
-                max_filecount: self.max_filecount,
-                current_filesize: self.current_filesize,
-                writer_opt: self.writer_opt,
-            }
-        )
+        Ok(RollingFileAppenderBase {
+            condition: self.condition,
+            filename: self.filename,
+            max_filecount: self.max_filecount,
+            current_filesize: self.current_filesize,
+            writer_opt: self.writer_opt,
+        })
     }
-
 }
-
 
 impl RollingFileAppenderBase {
     /// Creates a new rolling file appender builder instance with the default
@@ -173,9 +167,7 @@ impl RollingFileAppenderBase {
     pub fn builder() -> RollingFileAppenderBaseBuilder {
         RollingFileAppenderBaseBuilder::default()
     }
-
 }
-
 
 #[cfg(feature = "non-blocking")]
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
@@ -190,10 +182,8 @@ impl RollingFileAppenderBase {
     pub fn get_non_blocking_appender(self) -> (NonBlocking, WorkerGuard) {
         let (non_blocking, _guard) = non_blocking(self);
         (non_blocking, _guard)
-
     }
 }
-
 
 /// A rolling file appender with a rolling condition based on date/time or size.
 pub type RollingFileAppenderBase = RollingFileAppender<RollingConditionBase>;
@@ -231,7 +221,7 @@ mod test {
 
     fn build_builder_context(mut builder: RollingFileAppenderBaseBuilder) -> Context {
         if builder.filename.is_empty() {
-            builder =builder.filename(String::from("test.log"));
+            builder = builder.filename(String::from("test.log"));
         }
         let tempdir = tempfile::tempdir().unwrap();
         let filename = tempdir.path().join(&builder.filename);
@@ -240,7 +230,6 @@ mod test {
             _tempdir: tempdir,
             rolling: builder.build().unwrap(),
         }
-
     }
 
     #[test]
@@ -425,14 +414,17 @@ mod test {
     #[test]
     fn rolling_file_appender_builder() {
         let builder = RollingFileAppender::builder();
-        
-        let builder = builder
-            .condition_daily()
-            .condition_max_file_size(10);
+
+        let builder = builder.condition_daily().condition_max_file_size(10);
         let mut c = build_builder_context(builder);
-        c.rolling.write_with_datetime(b"abcdefghijklmnop", &Local.with_ymd_and_hms(2021, 3, 31, 4, 4, 4).unwrap())
+        c.rolling
+            .write_with_datetime(
+                b"abcdefghijklmnop",
+                &Local.with_ymd_and_hms(2021, 3, 31, 4, 4, 4).unwrap(),
+            )
             .unwrap();
-        c.rolling.write_with_datetime(b"12345678", &Local.with_ymd_and_hms(2021, 3, 31, 5, 4, 4).unwrap())
+        c.rolling
+            .write_with_datetime(b"12345678", &Local.with_ymd_and_hms(2021, 3, 31, 5, 4, 4).unwrap())
             .unwrap();
         assert!(AsRef::<Path>::as_ref(&c.rolling.filename_for(1)).exists());
         assert!(Path::new(&c.rolling.filename_for(0)).exists());
@@ -443,9 +435,7 @@ mod test {
     #[test]
     fn rolling_file_appender_builder_no_filename() {
         let builder = RollingFileAppender::builder();
-        let appender  = builder
-            .condition_daily()
-            .build();
+        let appender = builder.condition_daily().build();
         assert!(appender.is_err());
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -85,6 +85,116 @@ impl RollingCondition for RollingConditionBase {
     }
 }
 
+
+pub struct RollingFileAppenderBaseBuilder
+{
+    condition: RollingConditionBase,
+    filename: String,
+    max_filecount: usize,
+    current_filesize: u64,
+    writer_opt: Option<BufWriter<File>>,
+}    
+
+impl Default for RollingFileAppenderBaseBuilder {
+    fn default() -> Self {
+        RollingFileAppenderBaseBuilder {
+            condition: RollingConditionBase::default(),
+            filename: String::new(),
+            max_filecount: 10,
+            current_filesize: 0,
+            writer_opt: None,
+        }
+    }
+}
+
+impl RollingFileAppenderBaseBuilder {
+    /// Sets the log filename. Uses absolute path if provided, otherwise
+    /// creates files in the current working directory.
+    pub fn filename(mut self, filename: String) -> Self {
+        self.filename = filename;
+        self
+    }
+
+    /// Sets a condition for the maximum number of files to create before rolling
+    /// over and deleting the oldest one.
+    pub fn max_filecount(mut self, max_filecount: usize) -> Self {
+        self.max_filecount = max_filecount;
+        self
+    }
+
+    /// Sets a condition to rollover on a daily basis
+    pub fn condition_daily(mut self) -> Self {
+        self.condition.frequency_opt = Some(RollingFrequency::EveryDay);
+        self
+    }
+
+    /// Sets a condition to rollover when the date or hour changes
+    pub fn condition_hourly(mut self) -> Self {
+        self.condition.frequency_opt = Some(RollingFrequency::EveryHour);
+        self
+    }
+
+    /// Sets a condition to rollover when the date or minute changes
+    pub fn condition_minutely(mut self) -> Self {
+        self.condition.frequency_opt = Some(RollingFrequency::EveryMinute);
+        self
+    }
+
+    /// Sets a condition to rollover when a certain size is reached
+    pub fn condition_max_file_size(mut self, x: u64) -> Self {
+        self.condition.max_size_opt = Some(x);
+        self
+    }
+
+    /// Builds a RollingFileAppenderBase instance from the current settings.
+    ///
+    /// Returns an error if the filename is empty.
+    pub fn build(self) -> Result<RollingFileAppenderBase, &'static str> {
+        if self.filename.is_empty() {
+            return Err("A filename is required to be set and can not be blank")
+        }
+        Ok(
+            RollingFileAppenderBase {
+                condition: self.condition,
+                filename: self.filename,
+                max_filecount: self.max_filecount,
+                current_filesize: self.current_filesize,
+                writer_opt: self.writer_opt,
+            }
+        )
+    }
+
+}
+
+
+impl RollingFileAppenderBase {
+    /// Creates a new rolling file appender builder instance with the default
+    /// settings without a filename set.
+    pub fn builder() -> RollingFileAppenderBaseBuilder {
+        RollingFileAppenderBaseBuilder::default()
+    }
+
+}
+
+
+#[cfg(feature = "non-blocking")]
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+
+#[cfg(feature = "non-blocking")]
+use tracing_appender::non_blocking;
+
+#[cfg(feature = "non-blocking")]
+impl RollingFileAppenderBase {
+    /// Generates a non-blocking Struct wrapping the RollingFileAppender
+    /// instance inside and WorkerGuard returned as a tuple.
+    pub fn get_non_blocking_appender(self) -> (NonBlocking, WorkerGuard) {
+        let (non_blocking, _guard) = non_blocking(self);
+        (non_blocking, _guard)
+
+    }
+}
+
+
 /// A rolling file appender with a rolling condition based on date/time or size.
 pub type RollingFileAppenderBase = RollingFileAppender<RollingConditionBase>;
 
@@ -117,6 +227,20 @@ mod test {
             _tempdir: tempdir,
             rolling,
         }
+    }
+
+    fn build_builder_context(mut builder: RollingFileAppenderBaseBuilder) -> Context {
+        if builder.filename.is_empty() {
+            builder =builder.filename(String::from("test.log"));
+        }
+        let tempdir = tempfile::tempdir().unwrap();
+        let filename = tempdir.path().join(&builder.filename);
+        builder = builder.filename(String::from(filename.as_os_str().to_str().unwrap()));
+        Context {
+            _tempdir: tempdir,
+            rolling: builder.build().unwrap(),
+        }
+
     }
 
     #[test]
@@ -296,6 +420,33 @@ mod test {
         c.verify_contains("123456789", 2);
         c.verify_contains("0abcdefghijkl", 1);
         c.verify_contains("ZZZ", 0);
+    }
+
+    #[test]
+    fn rolling_file_appender_builder() {
+        let builder = RollingFileAppender::builder();
+        
+        let builder = builder
+            .condition_daily()
+            .condition_max_file_size(10);
+        let mut c = build_builder_context(builder);
+        c.rolling.write_with_datetime(b"abcdefghijklmnop", &Local.with_ymd_and_hms(2021, 3, 31, 4, 4, 4).unwrap())
+            .unwrap();
+        c.rolling.write_with_datetime(b"12345678", &Local.with_ymd_and_hms(2021, 3, 31, 5, 4, 4).unwrap())
+            .unwrap();
+        assert!(AsRef::<Path>::as_ref(&c.rolling.filename_for(1)).exists());
+        assert!(Path::new(&c.rolling.filename_for(0)).exists());
+        c.verify_contains("abcdefghijklmnop", 1);
+        c.verify_contains("12345678", 0);
+    }
+
+    #[test]
+    fn rolling_file_appender_builder_no_filename() {
+        let builder = RollingFileAppender::builder();
+        let appender  = builder
+            .condition_daily()
+            .build();
+        assert!(appender.is_err());
     }
 }
 // LCOV_EXCL_STOP

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@
 //! # }
 //! ```
 //!
-//! ## Builder
+//! ### Builder
 //!
-//! To simplify the creation of a `RollingFileAppenderBase`, the following builder methods are provided:
+//! To simplify the creation of a `RollingFileAppenderBase`, an instance can be built as per the example below.
 //!
 //! ```rust
 //! use tracing_rolling_file::*;
@@ -39,18 +39,18 @@
 //!     .unwrap();
 //! ```
 //!
-//! # Non-blocking support
+//! ### Non-blocking support
 //!
-//! To use non-blocking support, use the `tracing_appender::non_blocking::NonBlocking`
-//! the feature needs to be enabled in your Cargo.toml:
+//! To combine the `tracing_appender::non_blocking::NonBlocking` functionality,
+//! the feature needs to be enabled in Cargo.toml, i.e.
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-rolling-file = { version = "0.1.2", features = ["non-blocking"] }
+//! tracing-rolling-file = { version = "0.1.3", features = ["non-blocking"] }
 //! ```
 //!
-//! Once enabled you can use the method `get_non_blocking_appender` to generate
-//! a non-blocking version of the RollingFileAppender.
+//! Once enabled, you can use the method `get_non_blocking_appender` to generate
+//! a non-blocking version of the RollingFileAppenderBase.
 //!
 //! ```rust
 //! # #[cfg(feature = "non-blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,50 @@
 //! ).unwrap();
 //! # }
 //! ```
+//!
+//! ## Builder
+//!
+//! To simplify the creation of a `RollingFileAppenderBase`, the following builder methods are provided:
+//!
+//! ```rust
+//! use tracing_rolling_file::*;
+//!
+//! let builder = RollingFileAppenderBase::builder();
+//! let appender = builder
+//!     .filename(String::from("my_app.log"))
+//!     .max_filecount(10)
+//!     .condition_max_file_size(100)
+//!     .build()
+//!     .unwrap();
+//! ```
+//!
+//! # Non-blocking support
+//!
+//! To use non-blocking support, use the `tracing_appender::non_blocking::NonBlocking`
+//! the feature needs to be enabled in your Cargo.toml:
+//!
+//! ```toml
+//! [dependencies]
+//! tracing-rolling-file = { version = "0.1.2", features = ["non-blocking"] }
+//! ```
+//!
+//! Once enabled you can use the method `get_non_blocking_appender` to generate
+//! a non-blocking version of the RollingFileAppender.
+//!
+//! ```rust
+//! # #[cfg(feature = "non-blocking")]
+//! # fn docs() -> Result<(), Box<dyn std::error::Error>> {
+//! use tracing_rolling_file::*;
+//!
+//! let file_appender = RollingFileAppenderBase::new(
+//!     "/var/log/myprogram",
+//!     RollingConditionBase::new().daily(),
+//!     9
+//! )?;
+//! let (non_blocking, _guard) = file_appender.get_non_blocking_appender();
+//! # Ok(())
+//! # }
+//! ```
 #![deny(warnings)]
 
 use chrono::prelude::*;


### PR DESCRIPTION
## Feature: builder pattern and an optional feature for a non-blocking method to generate the worker.

I have been working on the proposed solution to enhance the `tracing-rolling-file` crate to simplify some of the use cases. I have forked the current version of the code, and I'm working on the final documentation.

### Builder pattern

The builder pattern would simplify the creation of the `RollingFileAppenderBase` and `RollingConditionBase` structs via abstraction and providing basic error handling.


```rust
use tracing_rolling_file::*;
 
let builder = RollingFileAppenderBase::builder();
let appender = builder
    .filename(String::from("my_app.log"))
    .max_filecount(10)
    .condition_max_file_size(100)
    .build()
    .unwrap();
```

### Feature (optional) non-blocking

The use of an optional feature to integrate the `non-blocking` capabilities via the cargo simplifies the user interaction. It ensures the correct dependencies have been installed and generates the `Worker` via the optional `method` implemented on the `RollingFileAppenderBase` struct.

#### Enabling the feature
```toml
[dependencies]
tracing-rolling-file = { version = "0.1.2", features = ["non-blocking"] }
```

#### Using the optional method
```rust
use tracing_rolling_file::*;
 
let file_appender = RollingFileAppenderBase::new(
    "/var/log/myprogram",
    RollingConditionBase::new().daily(),
    9
).unwrap();

let (non_blocking, _guard) = file_appender.get_non_blocking_appender();
```
